### PR TITLE
Use FT_Open() if FT_OpenEx() fails

### DIFF
--- a/FTDIDriver.cpp
+++ b/FTDIDriver.cpp
@@ -72,9 +72,14 @@ FTDIDriver::FTDIDriver(const string& serial, const string& layout)
 		FT_OPEN_BY_SERIAL_NUMBER,
 		&m_context)))
 	{
-		throw JtagExceptionWrapper(
-			"FT_OpenEx() failed",
-			"");
+		if(FT_OK != (err = FT_Open(
+			std::stoi(serial.c_str()),
+			&m_context)))
+		{
+			throw JtagExceptionWrapper(
+				"FT_OpenEx() && FT_OPen() both failed",
+				"");
+		}
 	}
 
 	//Get some info


### PR DESCRIPTION
Allow more relaxed FT_Open() as it is more convenient to find the default cable if you only have one (typical usecase).
Personally I couldn't get FT_OpenEx to find my Bus Blaster AT ALL.